### PR TITLE
fixes default option value (closes issue #26)

### DIFF
--- a/docopt.c
+++ b/docopt.c
@@ -286,7 +286,8 @@ int elems_to_args(Elements *elements, DocoptArgs *args, bool help,
         } else if (!strcmp(option->olong, "--version")) {
             args->version = option->value;
         } else if (!strcmp(option->olong, "--speed")) {
-            args->speed = option->argument;
+            if (option->argument)
+                args->speed = option->argument;
         }
     }
     /* commands */
@@ -363,3 +364,4 @@ DocoptArgs docopt(int argc, char *argv[], bool help, const char *version) {
         exit(EXIT_SUCCESS);
     return args;
 }
+

--- a/docopt_c.py
+++ b/docopt_c.py
@@ -91,7 +91,8 @@ def c_if_flag(o):
 
 def c_if_option(o):
     t = """ else if (!strcmp(option->o%s, %s)) {
-            args->%s = option->argument;
+            if (option->argument)
+                args->%s = option->argument;
         }"""
     return t % (('long' if o.long else 'short'),
                 to_c(o.long or o.short),


### PR DESCRIPTION
See #26 for context, but after these changes, we honor default options.

```
$ ./example.out
Commands
    mine == false
    move == false
    create == false
    remove == false
    set == false
    ship == false
    shoot == false
Arguments
    x == (null)
    y == (null)
Flags
    --drifting == false
    --help == false
    --moored == false
    --version == false
Options
    --speed == 10
```
