### PR TITLE
Fixed docopt_c to work in python 3.

### DIFF
--- a/docopt_c.py
+++ b/docopt_c.py
@@ -38,8 +38,12 @@ def to_c(s):
         return ('"%s"' % s.replace('\\', r'\\')\
                           .replace('"', r'\"')\
                           .replace('\n', '\\n"\n"'))
-    if type(s) in [int, long, float]:
-        return str(s)
+    if sys.version_info[0] >= 3: # Python 3 doesn't have longs!
+        if type(s) in [int, float]:
+            return str(s)
+    else:
+        if type(s) in [int, long, float]:
+            return str(s)
     if s is True:
         return '1'
     if s is False:


### PR DESCRIPTION
There was only one problem, really. Python 3 doesn't understand the long
keyword, since in python 3, longs are the same as ints. I added an if
statement to detect which version of python is being used. It then
either expects long or not as appropriate.

I tested this change by following the example, and everything seems to
work.