### PR TITLE
Added fallback for stdbool.h on Windows using MSVC

### DIFF
--- a/template.c
+++ b/template.c
@@ -5,8 +5,14 @@
 #else
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
+#ifdef _WIN32
+typedef int bool;
+#define false 0
+#define true 1
+#else
+#include <stdbool.h>
+#endif
 #endif
 
 


### PR DESCRIPTION
There is no stdbool.h on Windows (With MSVC). I've worked around this for now by changing the template. I don't know if this is the best way to handle this or if there is a better solution (Fancier ifdefs? Include an stdbool.h? Leave it up to the developer to implement/include?) But this commit is currently working for me.
