### PR TITLE
docs: fix simple typo, debuging -> debugging

### DIFF
--- a/log.h
+++ b/log.h
@@ -1,5 +1,5 @@
  /*
-  * log.h -- macros for logging and debuging.
+  * log.h -- macros for logging and debugging.
   *
   * Examples:
   *


### PR DESCRIPTION
There is a small typo in log.h.

Should read `debugging` rather than `debuging`.

